### PR TITLE
Remove redundant .clone() calls

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,10 @@ impl StdError for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(
+        &self,
+        fmt: &mut fmt::Formatter,
+    ) -> fmt::Result {
         match *self {
             Error::MissingValue(field) => write!(fmt, "missing value for field {}", field),
             Error::Custom(ref msg) => write!(fmt, "{}", msg),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl<Iter: Iterator<Item = (String, String)>> Iterator for Vars<Iter> {
     fn next(&mut self) -> Option<Self::Item> {
         self.0
             .next()
-            .map(|(k, v)| (VarName(k.clone()), Val(k, v.clone())))
+            .map(|(k, v)| (VarName(k.clone()), Val(k, v)))
     }
 }
 
@@ -137,7 +137,7 @@ macro_rules! forward_parsed_values {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for Val {
+impl<'de> de::Deserializer<'de> for Val {
     type Error = Error;
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,7 @@ impl<Iter: Iterator<Item = (String, String)>> Iterator for Vars<Iter> {
     type Item = (VarName, Val);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0
-            .next()
-            .map(|(k, v)| (VarName(k.clone()), Val(k, v)))
+        self.0.next().map(|(k, v)| (VarName(k.clone()), Val(k, v)))
     }
 }
 
@@ -139,14 +137,20 @@ macro_rules! forward_parsed_values {
 
 impl<'de> de::Deserializer<'de> for Val {
     type Error = Error;
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
         self.1.into_deserializer().deserialize_any(visitor)
     }
 
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_seq<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -154,7 +158,10 @@ impl<'de> de::Deserializer<'de> for Val {
         SeqDeserializer::new(values).deserialize_seq(visitor)
     }
 
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_option<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -185,7 +192,10 @@ impl<'de> de::Deserializer<'de> for Val {
 
 impl<'de> de::Deserializer<'de> for VarName {
     type Error = Error;
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -217,14 +227,20 @@ impl<'de, Iter: Iterator<Item = (String, String)>> de::Deserializer<'de>
     for Deserializer<'de, Iter>
 {
     type Error = Error;
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
         self.deserialize_map(visitor)
     }
 
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_map<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -274,7 +290,10 @@ impl<'a> Prefixed<'a> {
     }
 
     /// Deserializes a type based on prefixed (String, String) tuples
-    pub fn from_iter<Iter, T>(&self, iter: Iter) -> Result<T>
+    pub fn from_iter<Iter, T>(
+        &self,
+        iter: Iter,
+    ) -> Result<T>
     where
         T: de::DeserializeOwned,
         Iter: IntoIterator<Item = (String, String)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,9 @@ impl<Iter: Iterator<Item = (String, String)>> Iterator for Vars<Iter> {
     type Item = (VarName, Val);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (VarName(k.clone()), Val(k, v)))
+        self.0
+            .next()
+            .map(|(k, v)| (VarName(k.to_lowercase()), Val(k, v)))
     }
 }
 
@@ -270,9 +272,7 @@ where
     T: de::DeserializeOwned,
     Iter: IntoIterator<Item = (String, String)>,
 {
-    T::deserialize(Deserializer::new(
-        iter.into_iter().map(|(k, v)| (k.to_lowercase(), v)),
-    ))
+    T::deserialize(Deserializer::new(iter.into_iter()))
 }
 
 /// A type which filters env vars with a prefix for use as serde field inputs
@@ -431,7 +431,7 @@ mod tests {
             Ok(_) => panic!("expected failure"),
             Err(e) => assert_eq!(
                 e,
-                Error::Custom(String::from("provided string was not `true` or `false` while parsing environment variable $baz"))
+                Error::Custom(String::from("provided string was not `true` or `false` while parsing environment variable $BAZ"))
             ),
         }
     }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->
I read sources of `envy` and found two `.clone()` calls are unnecessary. I removed them by this PR. As a bonus, I removed an unused lifetime parameter. I did not change `CHANGELOG.md` since this is a small internal cleanup.

Closes: N/A

#### How did you verify your change:

I ran `cargo test` and all tests passed on my environment (macOS 10.12.6).

#### What (if anything) would need to be called out in the CHANGELOG for the next release: nothing