### PR TITLE
Improve error message by including variable name on parse error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,10 +27,7 @@ impl StdError for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(
-        &self,
-        fmt: &mut fmt::Formatter,
-    ) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::MissingValue(field) => write!(fmt, "missing value for field {}", field),
             Error::Custom(ref msg) => write!(fmt, "{}", msg),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,9 @@ impl<Iter: Iterator<Item = (String, String)>> Iterator for Vars<Iter> {
     type Item = (VarName, Val);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (VarName(k.clone()), Val(k, v.clone())))
+        self.0
+            .next()
+            .map(|(k, v)| (VarName(k.clone()), Val(k, v.clone())))
     }
 }
 
@@ -137,20 +139,14 @@ macro_rules! forward_parsed_values {
 
 impl<'de, 'a> de::Deserializer<'de> for Val {
     type Error = Error;
-    fn deserialize_any<V>(
-        self,
-        visitor: V,
-    ) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
         self.1.into_deserializer().deserialize_any(visitor)
     }
 
-    fn deserialize_seq<V>(
-        self,
-        visitor: V,
-    ) -> Result<V::Value>
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -158,10 +154,7 @@ impl<'de, 'a> de::Deserializer<'de> for Val {
         SeqDeserializer::new(values).deserialize_seq(visitor)
     }
 
-    fn deserialize_option<V>(
-        self,
-        visitor: V,
-    ) -> Result<V::Value>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -224,20 +217,14 @@ impl<'de, Iter: Iterator<Item = (String, String)>> de::Deserializer<'de>
     for Deserializer<'de, Iter>
 {
     type Error = Error;
-    fn deserialize_any<V>(
-        self,
-        visitor: V,
-    ) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
         self.deserialize_map(visitor)
     }
 
-    fn deserialize_map<V>(
-        self,
-        visitor: V,
-    ) -> Result<V::Value>
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -287,10 +274,7 @@ impl<'a> Prefixed<'a> {
     }
 
     /// Deserializes a type based on prefixed (String, String) tuples
-    pub fn from_iter<Iter, T>(
-        &self,
-        iter: Iter,
-    ) -> Result<T>
+    pub fn from_iter<Iter, T>(&self, iter: Iter) -> Result<T>
     where
         T: de::DeserializeOwned,
         Iter: IntoIterator<Item = (String, String)>,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->
While my trial, I noticed error message on parse error is not so useful. For example, when parsing `"hello"` as `u16`, I got following error:

```
invalid digit found in string
```

By this error, it's not clear that which variable is invalid.

This patch adds variable name to parse error message as follows:

```
invalid digit found in string while parsing environment variable $FOO
```

Closes: N/A

#### How did you verify your change:

I updated a test case and confirmed all tests passed on my local machine (macOS 10.12) with Rust compiler 1.32 (stable).

#### What (if anything) would need to be called out in the CHANGELOG for the next release: I feel nothing special