### PR TITLE
Don't fail Travis builds when nightly fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ branches:
 
 matrix:
   fast_finish: true
+  allow_failures:
+  - rust: nightly
   include:
   - rust: stable
   - rust: beta


### PR DESCRIPTION
As discussed, this Travis config change should just avoid failing builds if nightly fails, which often happens because of upstream changes.

(This PR is green even though nightly still fails, so it's working! :smile: )