### PR TITLE
Fix warning: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl<'a> Prefixed<'a> {
     {
         ::from_iter(iter.into_iter().filter_map(|(k, v)| {
             if k.starts_with(self.0.as_ref()) {
-                Some((k.trim_left_matches(self.0.as_ref()).to_owned(), v))
+                Some((k.trim_start_matches(self.0.as_ref()).to_owned(), v))
             } else {
                 None
             }


### PR DESCRIPTION
Fix warning: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`

