### PR TITLE
Fix small typos and punctuation in doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,11 @@
 //! ```
 //!
 //! Special treatment is given to collections. For config fields that store a `Vec` of values,
-//! use and env var that uses a comma separated value
+//! use an env var that uses a comma separated value.
 //!
-//! All serde modifier should work as is
+//! All serde modifiers should work as is.
 //!
-//! If you wish to use enum types use the following
+//! If you wish to use enum types use the following:
 //!
 //! ```no_run
 //! use serde::Deserialize;


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

A small documentation fix.

#### How did you verify your change:

I ran `cargo doc`.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

Nothing.