### PR TITLE
Add support for unit-variant enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1 (unreleased)
+
+* Add support for unit-variant enums as values, without using the `#[serde(field_identifier)]` attribute
+
 # 0.4.0
 
 * include field name and provided value in error messages [#28](https://github.com/softprops/envy/pull/28) [#36](https://github.com/softprops/envy/pull/36)

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             _ => None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,10 +184,22 @@ impl<'de> de::Deserializer<'de> for Val {
         visitor.visit_newtype_struct(self)
     }
 
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_enum(self.1.into_deserializer())
+    }
+
     serde::forward_to_deserialize_any! {
         char str string unit
         bytes byte_buf map unit_struct tuple_struct
-        identifier tuple ignored_any enum
+        identifier tuple ignored_any
         struct
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,13 @@
 //!
 //! All serde modifiers should work as is.
 //!
-//! If you wish to use enum types use the following:
+//! Enums with unit variants can be used as values:
 //!
 //! ```no_run
 //! use serde::Deserialize;
 //!
 //! #[derive(Deserialize, Debug, PartialEq)]
-//! #[serde(untagged)]
-//! #[serde(field_identifier, rename_all = "lowercase")]
+//! #[serde(rename_all = "lowercase")]
 //! pub enum Size {
 //!    Small,
 //!    Medium,
@@ -370,8 +369,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[derive(Deserialize, Debug, PartialEq)]
-    #[serde(untagged)]
-    #[serde(field_identifier, rename_all = "lowercase")]
+    #[serde(rename_all = "lowercase")]
     pub enum Size {
         Small,
         Medium,


### PR DESCRIPTION
## What did you implement:

Support for unit-variant enums as values, without need for `field_identifier` or `untagged` attributes. Most importantly, this allows enums with a remote Deserialize impl to be used without additional effort.

Relevant issue (currently closed): #39 

#### How did you verify your change:

Removed usage of `field_identifier` & `untagged` attributes in unit tests. The modified tests failed without this implementation, and now pass.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

(Hopefully) updated changelog appropriately.