### PR TITLE
Add test for potential name collision for prefixed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,4 +494,17 @@ mod tests {
             Ok(expected)
         );
     }
+
+    #[test]
+    fn prefixed_doesnt_parse_non_prefixed() {
+        let mut expected = HashMap::new();
+        expected.insert("foo".to_string(), 12);
+        assert_eq!(
+            prefixed("PRE_").from_iter(vec![
+                ("FOO".to_string(), "asd".to_string()),
+                ("PRE_FOO".to_string(), "12".to_string())
+            ]),
+            Ok(expected)
+        );
+    }
 }


### PR DESCRIPTION
I had an obscure bug in my application where the config wouldn't
deserialize due to a parsing error. I made an hypothesis that perhaps
`envy` deserialized `PORT` prior to `<PREFIX>_PORT`, even if only
"using" the latter. Hence if `PORT` then contains and invalid integer
the deserialization would fail. After some testing, this proved to be
wrong, and my problem was rather in my environment (where my
`<PREFIX>_PORT` was overwritten by an external source).

Despite my hypothesis being wrong, I figured it would be valuable to add
a test to prevent this possible regression (however unlikely).

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

Simply added a test to prevent a future regression.

#### How did you verify your change:

Ensure all tests are passing using:

```bash
cargo test
```

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

Nothing.