### PR TITLE
add support of hashmap in environment variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ coveralls = { repository = "softprops/envy" }
 travis-ci = { repository = "softprops/envy" }
 
 [dependencies]
+regex = "1.4.1"
 serde = "1.0"
 
 [dev-dependencies]

--- a/examples/prefixed.rs
+++ b/examples/prefixed.rs
@@ -1,13 +1,19 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Config {
     bar: Option<String>,
+    foo: HashMap<String, String>, // Must be formatted like "{key:value,key2:value2}"
 }
 
 fn main() {
     match envy::prefixed("FOO_").from_env::<Config>() {
-        Ok(config) => println!("provided config.bar {:?}", config.bar),
+        Ok(config) => println!(
+            "provided config.bar {:?} and config.foo {:?}",
+            config.bar, config.foo
+        ),
         Err(err) => println!("error parsing config from env: {}", err),
     }
 }


### PR DESCRIPTION
Hello, I wanted to add support of hashmap inside environment variable. I suggest this kind of syntax: `export FOO="{key:value, key2:value2}"`

I'm open to any suggestions :) 