### PR TITLE
Trim spaces in CSV env vars

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,10 @@ impl<'de> de::Deserializer<'de> for Val {
         if self.1.is_empty() {
             SeqDeserializer::new(empty::<Val>()).deserialize_seq(visitor)
         } else {
-            let values = self.1.split(',').map(|v| Val(self.0.clone(), v.to_owned()));
+            let values = self
+                .1
+                .split(',')
+                .map(|v| Val(self.0.clone(), v.trim().to_owned()));
             SeqDeserializer::new(values).deserialize_seq(visitor)
         }
     }
@@ -417,7 +420,7 @@ mod tests {
         let data = vec![
             (String::from("BAR"), String::from("test")),
             (String::from("BAZ"), String::from("true")),
-            (String::from("DOOM"), String::from("1,2,3")),
+            (String::from("DOOM"), String::from("1, 2, 3 ")),
             // Empty string should result in empty vector.
             (String::from("BOOM"), String::from("")),
             (String::from("SIZE"), String::from("small")),


### PR DESCRIPTION
## What did you implement:
Trim spaces on values in deserialize_seq.

This is for the niche use case of specifying env vars through kube manifests/yaml. We're passing ~10 IP CIDRs as an env var, and since spaces are preserved/break-the-next-level-of-deserialization there's not a simple way of making it readable.

#### How did you verify your change:
Modified existing test.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
This does change functionality if someone was counting on leading/trailing/only spaces showing up for a vec of strings. I think that's unlikely, but it would be a breaking change.
