### PR TITLE
Make Deserializer public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.3
+
+* Make `Deserializer` type public in order to allow to compose it with wrapper types
+
 # 0.4.2
 
 * Correctly deserialize empty strings into empty sequence [#51](https://github.com/softprops/envy/pull/51)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envy"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["softprops <d.tangren@gmail.com>"]
 description = "deserialize env vars into typesafe structs"
 documentation = "https://softprops.github.io/envy"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use crate::error::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Default)]
-struct VarsOptions {
+pub struct VarsOptions {
     keep_names: bool,
 }
 
@@ -261,12 +261,12 @@ impl<'de> de::Deserializer<'de> for VarName {
 }
 
 /// A deserializer for env vars
-struct Deserializer<'de, Iter: Iterator<Item = (String, String)>> {
+pub struct Deserializer<'de, Iter: Iterator<Item = (String, String)>> {
     inner: MapDeserializer<'de, Vars<Iter>, Error>,
 }
 
 impl<'de, Iter: Iterator<Item = (String, String)>> Deserializer<'de, Iter> {
-    fn new(
+    pub fn new(
         vars: Iter,
         options: Option<VarsOptions>,
     ) -> Self {


### PR DESCRIPTION
## What did you implement:

This change makes `Deserializer` type public. The motivation behind this is that `from_env()` function is too limiting and doesn't allow any control over the deserialization process. 

For example consider this program:

```rust
#[derive(serde::Deserialize, Debug)]
pub struct MyEnvConfig {
    pub my_super_arr: [i32; 1],
}

// export my_super_arr=loremIpsum && cargo run
fn main() -> Result<(), Box<dyn std::error::Error>>{
    let env_config: MyEnvConfig = envy::from_env()?;
    Ok(())
}
```

It will exit with an error code and text 

> Error: Custom("invalid type: string \"loremIpsum\", expected an array of length 1").

However if we wrap the deserializer (which we can thanks to https://github.com/dtolnay/path-to-error ) we can get much more information about what happened:

```rust
#[derive(serde::Deserialize, Debug)]
pub struct MyEnvConfig {
    pub my_super_arr: [i32; 1],
}


fn main() -> Result<(), Box<dyn std::error::Error>>{
    let mut jd = envy::Deserializer::new(std::env::vars(), None);
    let env_config: MyEnvConfig = serde_path_to_error::deserialize(jd)?;
    Ok(())
}
```

Will print:

> Error { path: Path { segments: [Map { key: "my_super_arr" }] }, original: Custom("invalid type: string \"loremIpsum\", expected an array of length 1") }


Now this is much better, because I can check the my_super_arr value.

I made this change specifically to be able to wrap into `serde_path_to_error`, because I have more than 100 env variables and some custom types do not mention name of the field that they failed to parse. For example primitive_types::H160 type says "expected string of length 40 but got 37". As you can imagine checking all the env strings for exact length is a very hard task.

But I think there are many other cases where wrapping the deserializer is desirable. Therefore, this type should be public 


#### How did you verify your change:

I used my fork in my app to see if it works correctly

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

I updated the CHANGELOG, but feel free to edit it whatever you please as I enable the "Allow edits by maintainers" checkbox.