### PR TITLE
Make deserializer public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ pub use crate::error::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Default)]
-struct VarsOptions {
-    keep_names: bool,
+pub struct VarsOptions {
+    pub keep_names: bool,
 }
 
 struct Vars<Iter>
@@ -266,7 +266,7 @@ pub struct Deserializer<'de, Iter: Iterator<Item = (String, String)>> {
 }
 
 impl<'de, Iter: Iterator<Item = (String, String)>> Deserializer<'de, Iter> {
-    fn new(
+    pub fn new(
         vars: Iter,
         options: Option<VarsOptions>,
     ) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ impl<'de> de::Deserializer<'de> for VarName {
 }
 
 /// A deserializer for env vars
-struct Deserializer<'de, Iter: Iterator<Item = (String, String)>> {
+pub struct Deserializer<'de, Iter: Iterator<Item = (String, String)>> {
     inner: MapDeserializer<'de, Vars<Iter>, Error>,
 }
 


### PR DESCRIPTION
I was trying to add eserde support to the deserializer and realized I couldn't without a public serializer.